### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "cordova-plugin-kiosk",
+  "version": "1.0.0",
+  "description": "Cordova plugin to create Cordova application with kiosk mode",
+  "cordova": {
+    "id": "cordova-plugin-kiosk",
+    "platforms": [
+      "android"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/honza889/cordova-plugin-kiosk.git"
+  },
+  "keywords": [
+    "cordova",
+    "android",
+    "kiosk",
+    "ecosystem:cordova",
+    "cordova-android"
+  ],
+  "author": "Jan Kalina",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/honza889/cordova-plugin-kiosk/issues"
+  },
+  "homepage": "https://github.com/honza889/cordova-plugin-kiosk"
+}


### PR DESCRIPTION
Starting in cordova 5, plugins were moved to npm, and this is the default place cordova will look now when using `cordova plugin add`.
fixes #20