### PR TITLE
fix: use TYPE_APPLICATION_OVERLAY instead of TYPE_SYYSTEM_ERROR for API 26 or later

### DIFF
--- a/android/StatusBarOverlay.java
+++ b/android/StatusBarOverlay.java
@@ -49,6 +49,10 @@ public class StatusBarOverlay extends ViewGroup {
         localLayoutParams.height = (int) (50 * activity.getResources().getDisplayMetrics().scaledDensity);
         localLayoutParams.format = PixelFormat.TRANSPARENT;
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            localLayoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        }
+
         StatusBarOverlay view = new StatusBarOverlay(activity);
         manager.addView(view, localLayoutParams);
 


### PR DESCRIPTION
Fixes an error that arises when a non-system application is defined and first opened from home (i.e. as a launcher) on Oreo+ devices. Namely, **`"android.view.WindowManager$BadTokenException: Unable to add window android.view.ViewRootImpl$W@cb3d890 -- permission denied for window type 2010"`** at `StatusBarOverlay.java:57`. 

See https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#TYPE_SYSTEM_ERROR for more details.